### PR TITLE
feat: add ability to turn off helm-release resources and write values to ssm

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Use of `sshuttle` with private key:
 | Name | Type |
 |------|------|
 | [aws_iam_role.auth_eks_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_ssm_parameter.helm_input_values](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [kubernetes_annotations.gp2](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/annotations) | resource |
 | [kubernetes_storage_class_v1.efs](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/storage_class_v1) | resource |
 | [kubernetes_storage_class_v1.gp3](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/storage_class_v1) | resource |
@@ -72,6 +73,7 @@ Use of `sshuttle` with private key:
 | <a name="input_aws_node_termination_handler"></a> [aws\_node\_termination\_handler](#input\_aws\_node\_termination\_handler) | AWS Node Termination Handler config for aws-ia/eks-blueprints-addon/aws | `any` | `{}` | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | n/a | `string` | `""` | no |
 | <a name="input_azs"></a> [azs](#input\_azs) | List of names of availability zones to use for subnet configs | `list(string)` | `[]` | no |
+| <a name="input_blueprints_addons_prefixes"></a> [blueprints\_addons\_prefixes](#input\_blueprints\_addons\_prefixes) | Prefixes for the eks blueprints addons, used to parse addon gitops\_metadata output and create objects with | `list(string)` | <pre>[<br>  "cert_manager",<br>  "cluster_autoscaler",<br>  "aws_cloudwatch_metrics",<br>  "aws_efs_csi_driver",<br>  "aws_fsx_csi_driver",<br>  "aws_privateca_issuer",<br>  "external_dns_route53",<br>  "external_secrets",<br>  "aws_load_balancer_controller",<br>  "aws_for_fluentbit",<br>  "aws_node_termination_handler",<br>  "karpenter",<br>  "velero",<br>  "aws_gateway_api_controller",<br>  "fargate_fluentbit_log"<br>]</pre> | no |
 | <a name="input_cidr_blocks"></a> [cidr\_blocks](#input\_cidr\_blocks) | n/a | `list(string)` | n/a | yes |
 | <a name="input_cluster_addons"></a> [cluster\_addons](#input\_cluster\_addons) | Nested of eks native add-ons and their associated parameters.<br>See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_add-on for supported values.<br>See https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/examples/complete/main.tf#L44-L60 for upstream example.<br><br>to see available eks marketplace addons available for your cluster's version run:<br>aws eks describe-addon-versions --kubernetes-version $k8s\_cluster\_version --query 'addons[].{MarketplaceProductUrl: marketplaceInformation.productUrl, Name: addonName, Owner: owner Publisher: publisher, Type: type}' --output table | `any` | `{}` | no |
 | <a name="input_cluster_autoscaler"></a> [cluster\_autoscaler](#input\_cluster\_autoscaler) | Cluster Autoscaler Helm Chart config | `any` | <pre>{<br>  "set": [<br>    {<br>      "name": "extraArgs.expander",<br>      "value": "priority"<br>    },<br>    {<br>      "name": "expanderPriorities",<br>      "value": "100:\n  - .*-spot-2vcpu-8mem.*\n90:\n  - .*-spot-4vcpu-16mem.*\n10:\n  - .*\n"<br>    }<br>  ]<br>}</pre> | no |
@@ -83,6 +85,8 @@ Use of `sshuttle` with private key:
 | <a name="input_control_plane_subnet_ids"></a> [control\_plane\_subnet\_ids](#input\_control\_plane\_subnet\_ids) | Subnet IDs for control plane | `list(string)` | `[]` | no |
 | <a name="input_create_aws_auth_configmap"></a> [create\_aws\_auth\_configmap](#input\_create\_aws\_auth\_configmap) | Determines whether to create the aws-auth configmap. NOTE - this is only intended for scenarios where the configmap does not exist (i.e. - when using only self-managed node groups). Most users should use `manage_aws_auth_configmap` | `bool` | `false` | no |
 | <a name="input_create_eni_configs"></a> [create\_eni\_configs](#input\_create\_eni\_configs) | Merge ENI configs for VPC CNI into cluster\_addons configuration | `bool` | `true` | no |
+| <a name="input_create_kubernetes_resources"></a> [create\_kubernetes\_resources](#input\_create\_kubernetes\_resources) | Create Kubernetes resource with Helm or Kubernetes provider | `bool` | `true` | no |
+| <a name="input_create_ssm_parameters"></a> [create\_ssm\_parameters](#input\_create\_ssm\_parameters) | Create SSM parameters for values from eks blueprints addons outputs | `bool` | `true` | no |
 | <a name="input_dataplane_wait_duration"></a> [dataplane\_wait\_duration](#input\_dataplane\_wait\_duration) | Duration to wait after the EKS cluster has become active before creating the dataplane components (EKS managed nodegroup(s), self-managed nodegroup(s), Fargate profile(s)) | `string` | `"4m"` | no |
 | <a name="input_eks_managed_node_group_defaults"></a> [eks\_managed\_node\_group\_defaults](#input\_eks\_managed\_node\_group\_defaults) | Map of EKS-managed node group default configurations | `any` | `{}` | no |
 | <a name="input_eks_managed_node_groups"></a> [eks\_managed\_node\_groups](#input\_eks\_managed\_node\_groups) | Managed node groups configuration | `any` | `{}` | no |
@@ -121,6 +125,7 @@ Use of `sshuttle` with private key:
 | <a name="output_cluster_security_group_id"></a> [cluster\_security\_group\_id](#output\_cluster\_security\_group\_id) | EKS cluster security group ID |
 | <a name="output_cluster_status"></a> [cluster\_status](#output\_cluster\_status) | status of the EKS cluster |
 | <a name="output_efs_storageclass_name"></a> [efs\_storageclass\_name](#output\_efs\_storageclass\_name) | The name of the EFS storageclass that was created (if var.enable\_amazon\_eks\_aws\_efs\_csi\_driver was set to true) |
+| <a name="output_eks_addons_gitops_metadata"></a> [eks\_addons\_gitops\_metadata](#output\_eks\_addons\_gitops\_metadata) | ############################################################################### EKS Addons metadata ############################################################################### see https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/outputs.tf#L167-L276 |
 | <a name="output_managed_nodegroups"></a> [managed\_nodegroups](#output\_managed\_nodegroups) | EKS managed node groups |
 | <a name="output_oidc_provider"></a> [oidc\_provider](#output\_oidc\_provider) | The OpenID Connect identity provider (issuer URL without leading `https://`) |
 | <a name="output_oidc_provider_arn"></a> [oidc\_provider\_arn](#output\_oidc\_provider\_arn) | EKS OIDC provider ARN |

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Use of `sshuttle` with private key:
 | <a name="input_secrets_store_csi_driver"></a> [secrets\_store\_csi\_driver](#input\_secrets\_store\_csi\_driver) | k8s Secret Store CSI Driver Helm Chart config | `any` | `{}` | no |
 | <a name="input_self_managed_node_group_defaults"></a> [self\_managed\_node\_group\_defaults](#input\_self\_managed\_node\_group\_defaults) | Map of self-managed node group default configurations | `any` | `{}` | no |
 | <a name="input_self_managed_node_groups"></a> [self\_managed\_node\_groups](#input\_self\_managed\_node\_groups) | Self-managed node groups configuration | `any` | `{}` | no |
+| <a name="input_ssm_parameter_key_arn"></a> [ssm\_parameter\_key\_arn](#input\_ssm\_parameter\_key\_arn) | KMS key ID for SSM parameters | `string` | `""` | no |
 | <a name="input_storageclass_reclaim_policy"></a> [storageclass\_reclaim\_policy](#input\_storageclass\_reclaim\_policy) | Reclaim policy for gp3 storage class, valid options are Delete and Retain | `string` | `"Delete"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to all resources | `map(string)` | `{}` | no |
 | <a name="input_vpc_cni_custom_subnet"></a> [vpc\_cni\_custom\_subnet](#input\_vpc\_cni\_custom\_subnet) | Subnet to put pod ENIs in | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Use of `sshuttle` with private key:
 | <a name="input_secrets_store_csi_driver"></a> [secrets\_store\_csi\_driver](#input\_secrets\_store\_csi\_driver) | k8s Secret Store CSI Driver Helm Chart config | `any` | `{}` | no |
 | <a name="input_self_managed_node_group_defaults"></a> [self\_managed\_node\_group\_defaults](#input\_self\_managed\_node\_group\_defaults) | Map of self-managed node group default configurations | `any` | `{}` | no |
 | <a name="input_self_managed_node_groups"></a> [self\_managed\_node\_groups](#input\_self\_managed\_node\_groups) | Self-managed node groups configuration | `any` | `{}` | no |
-| <a name="input_ssm_parameter_key_arn"></a> [ssm\_parameter\_key\_arn](#input\_ssm\_parameter\_key\_arn) | KMS key ID for SSM parameters | `string` | `""` | no |
+| <a name="input_ssm_parameter_key_arn"></a> [ssm\_parameter\_key\_arn](#input\_ssm\_parameter\_key\_arn) | KMS key arn for use with SSM parameter encryption/decryption | `string` | `""` | no |
 | <a name="input_storageclass_reclaim_policy"></a> [storageclass\_reclaim\_policy](#input\_storageclass\_reclaim\_policy) | Reclaim policy for gp3 storage class, valid options are Delete and Retain | `string` | `"Delete"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to all resources | `map(string)` | `{}` | no |
 | <a name="input_vpc_cni_custom_subnet"></a> [vpc\_cni\_custom\_subnet](#input\_vpc\_cni\_custom\_subnet) | Subnet to put pod ENIs in | `list(string)` | `[]` | no |

--- a/eks-addons.tf
+++ b/eks-addons.tf
@@ -126,6 +126,8 @@ locals {
         replace(k, "${prefix}_", "") => v if startswith(k, prefix)
     }) > 0
   }
+
+  ssm_parameter_key_arn = length(var.ssm_parameter_key_arn) > 0 ? var.ssm_parameter_key_arn : "alias/aws/ssm"
 }
 
 resource "aws_ssm_parameter" "helm_input_values" {
@@ -134,7 +136,7 @@ resource "aws_ssm_parameter" "helm_input_values" {
   name   = "/${local.cluster_name}/${each.key}_helm_input_values"
   value  = jsonencode(each.value)
   type   = "SecureString"
-  key_id = var.create_ssm_parameters ? var.ssm_parameter_key_arn : "alias/aws/ssm"
+  key_id = local.ssm_parameter_key_arn
   tier   = "Standard"
 
   tags = var.tags

--- a/eks-addons.tf
+++ b/eks-addons.tf
@@ -128,16 +128,14 @@ locals {
   }
 }
 
-
 resource "aws_ssm_parameter" "helm_input_values" {
-  #checkov:skip=CKV_AWS_337: TODO Need to encrypt this with KMS key
-  #checkov:skip=CKV2_AWS_34: TODO Need to encrypt this with KMS key
   for_each = var.create_ssm_parameters ? local.structured_gitops_metadata : {}
 
-  name  = "/${local.cluster_name}/${each.key}_helm_input_values"
-  value = jsonencode(each.value)
-  type  = "String"
-  tier  = "Standard"
+  name   = "/${local.cluster_name}/${each.key}_helm_input_values"
+  value  = jsonencode(each.value)
+  type   = "SecureString"
+  key_id = var.create_ssm_parameters ? var.ssm_parameter_key_arn : "alias/aws/ssm"
+  tier   = "Standard"
 
   tags = var.tags
 }

--- a/eks-addons.tf
+++ b/eks-addons.tf
@@ -21,6 +21,9 @@ module "eks_blueprints_kubernetes_addons" {
   # you don't need to tag eks managed node group ASGs for NTH - https://github.com/aws/aws-node-termination-handler/blob/main/README.md?plain=1#L41
   aws_node_termination_handler_asg_arns = local.node_group_arns
 
+  #this controls whether or not the cluster resources are created for the blueprints eks addons module
+  create_kubernetes_resources = var.create_kubernetes_resources
+
   # EKS EFS CSI Driver
   enable_aws_efs_csi_driver = var.enable_amazon_eks_aws_efs_csi_driver
   aws_efs_csi_driver        = var.aws_efs_csi_driver
@@ -103,6 +106,38 @@ module "efs" {
       cidr_blocks = var.cidr_blocks
     }
   }
+
+  tags = var.tags
+}
+
+################################################################################
+# SSM parameter creation
+################################################################################
+
+locals {
+  # creates a map of maps for each enabled addon, with the addon prefix as the key and then is used to create a json encoded string for the ssm parameter values
+  structured_gitops_metadata = {
+    for prefix in var.blueprints_addons_prefixes :
+    prefix => {
+      for k, v in module.eks_blueprints_kubernetes_addons.gitops_metadata :
+      replace(k, "${prefix}_", "") => v if startswith(k, prefix)
+      } if length({
+        for k, v in module.eks_blueprints_kubernetes_addons.gitops_metadata :
+        replace(k, "${prefix}_", "") => v if startswith(k, prefix)
+    }) > 0
+  }
+}
+
+
+resource "aws_ssm_parameter" "helm_input_values" {
+  #checkov:skip=CKV_AWS_337: TODO Need to encrypt this with KMS key
+  #checkov:skip=CKV2_AWS_34: TODO Need to encrypt this with KMS key
+  for_each = var.create_ssm_parameters ? local.structured_gitops_metadata : {}
+
+  name  = "/${local.cluster_name}/${each.key}_helm_input_values"
+  value = jsonencode(each.value)
+  type  = "String"
+  tier  = "Standard"
 
   tags = var.tags
 }

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -163,6 +163,8 @@ kubectl get nodes
 | <a name="input_cluster_endpoint_public_access"></a> [cluster\_endpoint\_public\_access](#input\_cluster\_endpoint\_public\_access) | Whether to enable private access to the EKS cluster | `bool` | `false` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Kubernetes version to use for EKS cluster | `string` | `"1.26"` | no |
 | <a name="input_create_aws_auth_configmap"></a> [create\_aws\_auth\_configmap](#input\_create\_aws\_auth\_configmap) | Determines whether to create the aws-auth configmap. NOTE - this is only intended for scenarios where the configmap does not exist (i.e. - when using only self-managed node groups). Most users should use `manage_aws_auth_configmap` | `bool` | `false` | no |
+| <a name="input_create_kubernetes_resources"></a> [create\_kubernetes\_resources](#input\_create\_kubernetes\_resources) | If true, kubernetes resources related to non-marketplace addons to will be created | `bool` | `true` | no |
+| <a name="input_create_ssm_parameters"></a> [create\_ssm\_parameters](#input\_create\_ssm\_parameters) | Create SSM parameters for values from eks blueprints addons | `bool` | `true` | no |
 | <a name="input_dataplane_wait_duration"></a> [dataplane\_wait\_duration](#input\_dataplane\_wait\_duration) | The duration to wait for the EKS cluster to be ready before creating the node groups | `string` | `"30s"` | no |
 | <a name="input_eks_use_mfa"></a> [eks\_use\_mfa](#input\_eks\_use\_mfa) | Use MFA for auth\_eks\_role | `bool` | n/a | yes |
 | <a name="input_eks_worker_tenancy"></a> [eks\_worker\_tenancy](#input\_eks\_worker\_tenancy) | The tenancy of the EKS worker nodes | `string` | `"default"` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -119,6 +119,7 @@ kubectl get nodes
 | <a name="module_ebs_kms_key"></a> [ebs\_kms\_key](#module\_ebs\_kms\_key) | terraform-aws-modules/kms/aws | ~> 2.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | ../.. | n/a |
 | <a name="module_key_pair"></a> [key\_pair](#module\_key\_pair) | terraform-aws-modules/key-pair/aws | ~> 2.0 |
+| <a name="module_ssm_kms_key"></a> [ssm\_kms\_key](#module\_ssm\_kms\_key) | terraform-aws-modules/kms/aws | ~> 2.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | git::https://github.com/defenseunicorns/terraform-aws-vpc.git | v0.1.4 |
 
 ## Resources
@@ -128,7 +129,6 @@ kubectl get nodes
 | [aws_iam_policy.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_kms_alias.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
-| [aws_kms_key.ssm_parameter_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_s3_bucket.access_log_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_lifecycle_configuration.access_log_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_notification.access_log_bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
@@ -144,7 +144,6 @@ kubectl get nodes
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.kms_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.ssm_kms_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -128,6 +128,7 @@ kubectl get nodes
 | [aws_iam_policy.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_kms_alias.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_kms_key.ssm_parameter_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_s3_bucket.access_log_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_lifecycle_configuration.access_log_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_notification.access_log_bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
@@ -143,6 +144,7 @@ kubectl get nodes
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.kms_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ssm_kms_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs

--- a/examples/complete/fixtures.common.tfvars
+++ b/examples/complete/fixtures.common.tfvars
@@ -23,7 +23,7 @@ zarf_version         = "v0.29.1"
 ###########################################################
 #################### EKS Config ###########################
 
-cluster_version = "1.26"
+cluster_version = "1.27"
 
 # #################### EKS Addon #########################
 # add other "eks native" marketplace addons and configs to this list
@@ -89,16 +89,6 @@ enable_cluster_autoscaler = true
 cluster_autoscaler = {
   wait          = false
   chart_version = "v9.29.1"
-  # set = [
-  #   {
-  #     name  = "extraArgs.expander"
-  #     value = "priority"
-  #   },
-  #   {
-  #     name  = "image.tag"
-  #     value = "v1.27.2"
-  #   }
-  # ]
 }
 
 enable_metrics_server = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -279,9 +279,11 @@ module "ssm_kms_key" {
     data.aws_caller_identity.current.arn
   ]
 
-  computed_aliases = [
-    "${local.kms_key_alias_name_prefix}-ssm"
-  ]
+  computed_aliases = {
+    ssm = {
+      name = "${local.kms_key_alias_name_prefix}-ssm"
+    }
+  }
 
   key_statements = {
     sid    = "SSM service access"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -314,6 +314,9 @@ module "eks" {
   # EKS Blueprints - blueprints curated helm charts
   #---------------------------------------------------------------
 
+  create_kubernetes_resources = var.create_kubernetes_resources
+  create_ssm_parameters       = var.create_ssm_parameters
+
   # AWS EKS EBS CSI Driver
   enable_amazon_eks_aws_ebs_csi_driver = var.enable_amazon_eks_aws_ebs_csi_driver
   enable_gp3_default_storage_class     = var.enable_gp3_default_storage_class

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -285,22 +285,26 @@ module "ssm_kms_key" {
     }
   }
 
-  key_statements = {
-    sid    = "SSM service access"
-    effect = "Allow"
-    principals = {
-      type        = "Service"
-      identifiers = ["ssm.amazonaws.com"]
+  key_statements = [
+    {
+      sid    = "SSM service access"
+      effect = "Allow"
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["ssm.amazonaws.com"]
+        }
+      ]
+      actions = [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+      ]
+      resources = ["*"]
     }
-    actions = [
-      "kms:Decrypt",
-      "kms:Encrypt",
-      "kms:ReEncrypt*",
-      "kms:GenerateDataKey*",
-      "kms:DescribeKey",
-    ]
-    resources = ["*"]
-  }
+  ]
 
   tags = local.tags
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -144,6 +144,19 @@ EOD
   default     = {}
 }
 
+variable "create_kubernetes_resources" {
+  description = "If true, kubernetes resources related to non-marketplace addons to will be created"
+  type        = bool
+  default     = true
+}
+
+variable "create_ssm_parameters" {
+  description = "Create SSM parameters for values from eks blueprints addons"
+  type        = bool
+  default     = true
+}
+
+
 #----------------AWS EBS CSI Driver-------------------------
 variable "enable_amazon_eks_aws_ebs_csi_driver" {
   description = "Enable EKS Managed AWS EBS CSI Driver add-on"

--- a/outputs.tf
+++ b/outputs.tf
@@ -55,3 +55,12 @@ output "cluster_security_group_id" {
   description = "EKS cluster security group ID"
   value       = module.aws_eks.cluster_security_group_id
 }
+
+################################################################################
+# EKS Addons metadata
+################################################################################
+# see https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/outputs.tf#L167-L276
+output "eks_addons_gitops_metadata" {
+  description = ""
+  value       = try(module.eks_blueprints_kubernetes_addons.gitops_metadata, null)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -228,6 +228,12 @@ variable "create_ssm_parameters" {
   default     = true
 }
 
+variable "ssm_parameter_key_arn" {
+  description = "KMS key arn for use with SSM parameter encryption/decryption"
+  type        = string
+  default     = ""
+}
+
 #----------------AWS EBS CSI Driver-------------------------
 variable "enable_amazon_eks_aws_ebs_csi_driver" {
   description = "Enable EKS Managed AWS EBS CSI Driver add-on"

--- a/variables.tf
+++ b/variables.tf
@@ -192,8 +192,41 @@ EOD
   default     = {}
 }
 
-####################################################################
-################## AWS EKS Marketplace Addons ######################
+########################################################
+
+variable "create_kubernetes_resources" {
+  description = "Create Kubernetes resource with Helm or Kubernetes provider"
+  type        = bool
+  default     = true
+}
+
+variable "blueprints_addons_prefixes" {
+  description = "Prefixes for the eks blueprints addons, used to parse addon gitops_metadata output and create objects with"
+  type        = list(string)
+  default = [
+    "cert_manager",
+    "cluster_autoscaler",
+    "aws_cloudwatch_metrics",
+    "aws_efs_csi_driver",
+    "aws_fsx_csi_driver",
+    "aws_privateca_issuer",
+    "external_dns_route53",
+    "external_secrets",
+    "aws_load_balancer_controller",
+    "aws_for_fluentbit",
+    "aws_node_termination_handler",
+    "karpenter",
+    "velero",
+    "aws_gateway_api_controller",
+    "fargate_fluentbit_log",
+  ]
+}
+
+variable "create_ssm_parameters" {
+  description = "Create SSM parameters for values from eks blueprints addons outputs"
+  type        = bool
+  default     = true
+}
 
 #----------------AWS EBS CSI Driver-------------------------
 variable "enable_amazon_eks_aws_ebs_csi_driver" {


### PR DESCRIPTION
Supports: #94

This pull request adds the ability to turn off helm-release resources and write values to SSM. It includes changes to the eks module, adding the variables create_kubernetes_resources and create_ssm_parameters, and updates to the gitops_metadata output. Additionally, it introduces the creation of SSM parameters for the values from eks blueprints addons.