### PR TITLE
fix: logic error for efs fsid ssm paramter count

### DIFF
--- a/eks-addons.tf
+++ b/eks-addons.tf
@@ -135,8 +135,6 @@ locals {
   }
 
   ssm_parameter_key_arn = length(var.ssm_parameter_key_arn) > 0 ? var.ssm_parameter_key_arn : "alias/aws/ssm"
-
-  file_system_id = !var.create_kubernetes_resources && var.enable_amazon_eks_aws_efs_csi_driver ? module.efs[0].id : ""
 }
 
 resource "aws_ssm_parameter" "helm_input_values" {
@@ -152,9 +150,9 @@ resource "aws_ssm_parameter" "helm_input_values" {
 }
 
 resource "aws_ssm_parameter" "file_system_id_for_efs_storage_class" {
-  count  = var.create_ssm_parameters && local.file_system_id != "" ? 1 : 0
+  count  = var.create_ssm_parameters && var.enable_amazon_eks_aws_efs_csi_driver ? 1 : 0
   name   = "/${local.cluster_name}/StorageClass/efs/fileSystemId"
-  value  = local.file_system_id
+  value  = module.efs[0].id
   type   = "SecureString"
   key_id = local.ssm_parameter_key_arn
   tier   = "Standard"


### PR DESCRIPTION
This was causing a deploy time error: 

```
│ Error: Invalid count argument
│ 
│   on .terraform/modules/eks/eks-addons.tf line 155, in resource "aws_ssm_parameter" "file_system_id_for_efs_storage_class":
│  155:   count  = var.create_ssm_parameters && local.file_system_id != "" ? 1 : 0
│ 
│ The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created. To work around this, use the -target argument to first apply only the
│ resources that the count depends on.
```