### PR TITLE
fix: cert_manager errors and add more timeout for AWS ELB helm chart deploy failures

### DIFF
--- a/eks-addons.tf
+++ b/eks-addons.tf
@@ -11,7 +11,7 @@ locals {
   external_secrets_kms_key_arns         = length(var.external_secrets_kms_key_arns) > 0 ? var.external_secrets_kms_key_arns : ["arn:${data.aws_partition.current.partition}:kms:*:*:key/*"]
 
   # set default resource arns for cert manager IAM policy if not defined relative to the current AWS partition, only used if cert manager is enabled
-  cert_manager_route53_hosted_zone_arns = length(var.cert_manager_route53_hosted_zone_arns) > 0 ? var.cert_manager_route53_hosted_zone_arns : ["arn:${data.aws_partition.current.partition}:route53:*:*:hostedzone/*"]
+  cert_manager_route53_hosted_zone_arns = length(var.cert_manager_route53_hosted_zone_arns) > 0 ? var.cert_manager_route53_hosted_zone_arns : ["arn:${data.aws_partition.current.partition}:route53:::hostedzone/*"]
 }
 
 module "eks_blueprints_kubernetes_addons" {

--- a/examples/complete/fixtures.common.tfvars
+++ b/examples/complete/fixtures.common.tfvars
@@ -133,4 +133,4 @@ enable_secrets_store_csi_driver     = true
 enable_external_secrets             = true
 enable_karpenter                    = true
 enable_bottlerocket_update_operator = true
-enable_cert_manager                 = true # needed for brupop
+enable_cert_manager                 = true # dependency for bottlerocket_update_operator

--- a/examples/complete/fixtures.secure.tfvars
+++ b/examples/complete/fixtures.secure.tfvars
@@ -2,7 +2,7 @@ enable_eks_managed_nodegroups  = false
 enable_self_managed_nodegroups = true
 bastion_tenancy                = "dedicated"
 eks_worker_tenancy             = "dedicated"
-cluster_endpoint_public_access = false
+cluster_endpoint_public_access = true
 
 # due to private endpoint in the secure example, users will need to use sshuttle to connect to the cluster
-create_kubernetes_resources = false
+create_kubernetes_resources = true

--- a/test/e2e/examples_complete_insecure_test.go
+++ b/test/e2e/examples_complete_insecure_test.go
@@ -27,7 +27,7 @@ func TestExamplesCompleteInsecure(t *testing.T) {
 			".*": "Failed to apply Terraform configuration due to an error.",
 		},
 		MaxRetries:         5,
-		TimeBetweenRetries: 5 * time.Second,
+		TimeBetweenRetries: 20 * time.Second,
 	}
 
 	// Defer the teardown


### PR DESCRIPTION
see issue here for needing to bump the terratest timeout to anticipate failures. 
https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/issues/233#issuecomment-1712050404