### PR TITLE
fix: Add cluster ARN to outputs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Use of `sshuttle` with private key:
 
 | Name | Description |
 |------|-------------|
+| <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | The ARN of the EKS cluster |
 | <a name="output_cluster_certificate_authority_data"></a> [cluster\_certificate\_authority\_data](#output\_cluster\_certificate\_authority\_data) | EKS cluster certificate authority data |
 | <a name="output_cluster_endpoint"></a> [cluster\_endpoint](#output\_cluster\_endpoint) | EKS cluster endpoint |
 | <a name="output_cluster_iam_role_arn"></a> [cluster\_iam\_role\_arn](#output\_cluster\_iam\_role\_arn) | EKS cluster IAM role ARN |

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "cluster_arn" {
+  description = "The ARN of the EKS cluster"
+  value       = module.aws_eks.cluster_arn
+}
+
 output "cluster_name" {
   description = "The name of the EKS cluster"
   value       = module.aws_eks.cluster_name


### PR DESCRIPTION
I would like to use this output in order to create an IAM policy using this ARN in the resource section.  [Upstream output](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/outputs.tf#L5C8-L5C23).