### PR TITLE
fix: constrain version for `iam-role-for-service-accounts-eks` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To view examples for how you can leverage this EKS Module, please see the [examp
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_aws_eks"></a> [aws\_eks](#module\_aws\_eks) | git::https://github.com/terraform-aws-modules/terraform-aws-eks.git | v20.24.0 |
-| <a name="module_ebs_csi_driver_irsa"></a> [ebs\_csi\_driver\_irsa](#module\_ebs\_csi\_driver\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.20 |
+| <a name="module_ebs_csi_driver_irsa"></a> [ebs\_csi\_driver\_irsa](#module\_ebs\_csi\_driver\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.20, < 5.47 |
 | <a name="module_efs"></a> [efs](#module\_efs) | terraform-aws-modules/efs/aws | ~> 1.0 |
 | <a name="module_efs_csi_driver_irsa"></a> [efs\_csi\_driver\_irsa](#module\_efs\_csi\_driver\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.20 |
 | <a name="module_eks_blueprints_kubernetes_addons"></a> [eks\_blueprints\_kubernetes\_addons](#module\_eks\_blueprints\_kubernetes\_addons) | git::https://github.com/aws-ia/terraform-aws-eks-blueprints-addons.git | v1.16.3 |

--- a/main.tf
+++ b/main.tf
@@ -179,7 +179,7 @@ module "aws_eks" {
 
 module "ebs_csi_driver_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.20"
+  version = "~> 5.20, < 5.47"
 
   count = var.enable_amazon_eks_aws_ebs_csi_driver ? 1 : 0
 


### PR DESCRIPTION
constrain version to prevent inheritance of breaking changes as described [here](https://github.com/terraform-aws-modules/terraform-aws-iam/issues/531) 